### PR TITLE
prevents overriding manually changed translations

### DIFF
--- a/translate.js
+++ b/translate.js
@@ -124,7 +124,8 @@ var run = function(apiKey, dir, sourceLanguage, languages, finish) {
         async.map(languages, function(language, translated) {
 
           // check if translation already exists at path
-          if (targets[language].get(path) !== traversed.get(path)) {
+          var targetText = targets[language].get(path);
+          if (targetText && targetText !== traversed.get(path)) {
             return translated(null, null);
           }
 

--- a/translate.js
+++ b/translate.js
@@ -80,12 +80,8 @@ var run = function(apiKey, dir, sourceLanguage, languages, finish) {
         var lang = languages[l];
 
         // read existing translation file
-        var langData;
-
         try {
-          langData = fs.readFileSync(dir + lang + ".json", "utf8");
-
-          langData = langData.toString();
+          var langData = fs.readFileSync(dir + lang + ".json", "utf8").toString();
 
           var langParsed;
 


### PR DESCRIPTION
This change prevents the script from rewriting all translation files every time it runs. This allows manual adjustments of individual translations as needed, as well as minimises requests to Google Translation API only to those lines that have been added. 

The solution taken has one **important drawback**: If some text changes in source language, but the key it's located at doesn't, the script will not run for that text (condition is simply `source text !== translation text`). One could mitigate that by having the script create a backup source file every time, and reference it on next translation run, but this has been left out of this PR.